### PR TITLE
Adds sensible error messages if listenTo is trying to listen to undefined or a non-amp-events object

### DIFF
--- a/.zuul.yml
+++ b/.zuul.yml
@@ -7,6 +7,6 @@ browsers:
   - name: safari
     version: latest
   - name: ie
-    version: 6..latest
+    version: 9..latest
   - name: iphone
     version: 6.1

--- a/ampersand-events.js
+++ b/ampersand-events.js
@@ -162,10 +162,16 @@ var listenMethods = {
 // listening to.
 each(listenMethods, function(implementation, method) {
     Events[method] = function(obj, name, callback, run) {
+        if (!obj) {
+            throw new Error('Trying to listenTo event: \'' + name + '\' but the target object is undefined');
+        }
         var listeningTo = this._listeningTo || (this._listeningTo = {});
         var id = obj._listenId || (obj._listenId = uniqueId('l'));
         listeningTo[id] = obj;
         if (!callback && typeof name === 'object') callback = this;
+        if (typeof obj[implementation] !== 'function') {
+            throw new Error('Trying to listenTo event: \'' + name + '\' on object: ' + obj.toString() + ' but it does not have an \'on\' method so is unbindable');
+        }
         obj[implementation](name, callback, this);
         return this;
     };

--- a/test/index.js
+++ b/test/index.js
@@ -617,3 +617,22 @@ test('createEmitter', function (t) {
 
     t.end();
 });
+
+test('throws a useful error if listening to an undefined object with listenTo', function (t) {
+    t.plan(1);
+    var view = extend({}, Events);
+    t.throws(function () {
+        view.listenTo(undefined, 'test', function () {});
+    }, /Trying to listenTo event: 'test'/);
+    t.end();
+});
+
+test('throws a useful error if listening to a non-bindable object with listenTo', function (t) {
+    t.plan(1);
+    var view = extend({}, Events);
+    t.throws(function () {
+        view.listenTo(5, 'test', function () {});
+    }, /Trying to listenTo event: 'test'/);
+    t.end();
+
+});


### PR DESCRIPTION
Got fed up of: 

![665deb60-57b4-4eda-9131-3d0a287ef91f 2015-05-24 21-08-47](https://cloud.githubusercontent.com/assets/78225/7789459/13e736b4-0259-11e5-9f71-31ce3ddead21.png)
