### PR TITLE
Fix stale references to extend in tests, caused by me forking off old code

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -620,7 +620,7 @@ test('createEmitter', function (t) {
 
 test('throws a useful error if listening to an undefined object with listenTo', function (t) {
     t.plan(1);
-    var view = extend({}, Events);
+    var view = assign({}, Events);
     t.throws(function () {
         view.listenTo(undefined, 'test', function () {});
     }, /Trying to listenTo event: 'test'/);
@@ -629,7 +629,7 @@ test('throws a useful error if listening to an undefined object with listenTo', 
 
 test('throws a useful error if listening to a non-bindable object with listenTo', function (t) {
     t.plan(1);
-    var view = extend({}, Events);
+    var view = assign({}, Events);
     t.throws(function () {
         view.listenTo(5, 'test', function () {});
     }, /Trying to listenTo event: 'test'/);


### PR DESCRIPTION
I had forked off of an old head, which was pre amp -> lodash move, so my merged tests broke, :facepalm:
