### PR TITLE
Correct callback context for `once`

### DIFF
--- a/ampersand-events.js
+++ b/ampersand-events.js
@@ -26,7 +26,7 @@ var Events = {
         var self = this;
         var once = runOnce(function () {
             self.off(name, once);
-            callback.apply(self, arguments);
+            callback.apply(this, arguments);
         });
         once._callback = callback;
         return this.on(name, once, context);

--- a/test/index.js
+++ b/test/index.js
@@ -460,11 +460,12 @@ test('once variant two', function (t) {
     var obj = assign({}, Events);
 
     obj
-        .once('event', f)
-        .on('event', f)
-        .trigger('event')
-        .trigger('event');
-        t.end();
+    .once('event', f)
+    .on('event', f)
+    .trigger('event')
+    .trigger('event');
+    
+    t.end();
 });
 
 test('once with off', function (t) {
@@ -503,6 +504,23 @@ test('once with event maps', function (t) {
 
     obj.trigger('a b c');
     t.equal(obj.counter, 3);
+    t.end();
+});
+
+test('bind a callback with a supplied context when using once', function (t) {
+    t.plan(1);
+    
+    var TestClass = function () {
+        return this;
+    };
+    
+    TestClass.prototype.assertTrue = function () {
+        t.ok(true, '`this` was bound to the callback');
+    };
+
+    var obj = assign({},Events);
+    obj.once('event', function () { this.assertTrue(); }, (new TestClass()));
+    obj.trigger('event');
     t.end();
 });
 


### PR DESCRIPTION
This reverts L29 of ampersand-events.js in c7f2ccafea3c462c8761d87944930392fdeebf8e, restoring the correct context for the callback, when it's invoked later on.

Closes #18
